### PR TITLE
Run `qmk userspace-doctor` before build in order to pick up `qmk.json` schema issues.

### DIFF
--- a/.github/workflows/qmk_userspace_build.yml
+++ b/.github/workflows/qmk_userspace_build.yml
@@ -57,6 +57,10 @@ jobs:
           qmk config user.qmk_home=$GITHUB_WORKSPACE/qmk_firmware
           qmk config user.overlay_dir=$GITHUB_WORKSPACE
 
+      - name: Validate userspace
+        run: |
+          qmk userspace-doctor
+
       - name: Build
         run: |
           qmk userspace-compile -e DUMP_CI_METADATA=yes || touch .failed


### PR DESCRIPTION
As per title.
Someone on discord was attempting to build on GHA with an invalid `qmk.json` but there's no indication _why_ -- it just doesn't "find" the userspace directory as a result.