### PR TITLE
Allow setting release name to something other than `latest`

### DIFF
--- a/.github/workflows/qmk_userspace_publish.yml
+++ b/.github/workflows/qmk_userspace_publish.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       release_name:
-        description: ""
+        description: "allow setting the release name"
         default: "latest"
         required: false
         type: string

--- a/.github/workflows/qmk_userspace_publish.yml
+++ b/.github/workflows/qmk_userspace_publish.yml
@@ -2,6 +2,12 @@ name: Build Binaries
 
 on:
   workflow_call:
+    inputs:
+      release_name:
+        description: ""
+        default: "latest"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -23,7 +29,7 @@ jobs:
         with:
           token: ${{ github.token }}
           name: Latest QMK Firmware
-          tag_name: latest
+          tag_name: ${{ inputs.release_name || 'latest' }}
           fail_on_unmatched_files: false
           draft: false
           prerelease: false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description
Allow setting release name to something other than `latest`

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
In an attempt to handle multiple releases, it would be nice to be able to set release name to something other than `latest` all the time.