### PR TITLE
Enabling github actions to build non-tree keyboards stored in userspace

### DIFF
--- a/.github/workflows/qmk_userspace_build.yml
+++ b/.github/workflows/qmk_userspace_build.yml
@@ -13,6 +13,11 @@ on:
         default: "master"
         required: false
         type: string
+      qmk_nontree_json:
+        description: "json file containing non-tree keyboards"
+        default: "qmk_nontree.json"
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -60,6 +65,31 @@ jobs:
       - name: Validate userspace
         run: |
           qmk userspace-doctor
+
+      - name: Check if non-tree keyboard json file exists
+        id: check_json_files
+        uses: andstor/file-existence-action@v2
+        with:
+          files: ${{ inputs.qmk_nontree_json }}
+
+      - name: Read Non-Tree Targets from JSON file
+        if: steps.check_json_files.outputs.files_exists == 'true'
+        run: |
+          {
+            echo 'COPY_TARGETS<<EOF'
+            cat $GITHUB_WORKSPACE/${{ inputs.qmk_nontree_json }}
+            echo
+            echo 'EOF'
+          } >> "$GITHUB_ENV"
+
+      - name: Copy Non-Tree Keyboard Definitions from Userspace to QMK Firmware
+        if: steps.check_json_files.outputs.files_exists == 'true'
+        run: |
+          for target in ${{ join(fromJson(env.COPY_TARGETS).nontree_targets, ' ') }};
+          do
+            echo "Copying keyboard: $target"
+            cp $GITHUB_WORKSPACE/keyboards/$target $GITHUB_WORKSPACE/qmk_firmware/keyboards -R
+          done
 
       - name: Build
         run: |


### PR DESCRIPTION
Been utilizing the qmk_userspace / github actions functionality to build firmware without having to setup a local build environment and maintain a qmk_firmware fork. I stumbled into the situation where I had a keyboard (Barbellboards Rollow) that did not exist in qmk_firmware. I will call it "non-tree" for lack of better term. 

Discord confirmed I would not be able to use qmk_userspace feature to build firmware for this board. I saw several instances on Discord/Reddit of users asking how to build firmware for keyboards that don't currently exist.

While I could build locally or submit a PR to get Rollow included, decided on this route because I can see this enhancement be useful for several reasons
- should help those who build low volume (e.g. Rollow) or one off boards avoid installing/maintaining a local build environment
- the implementation only impacts the container and not qmk_firmware repo
- To add to the above, one can use this implementation to test bug fixes before PR or override keyboard maintainer defaults without impacting others
- less boards for qmk_firmware to maintain
- I want to contribute to a project that gave so much to me

## Description

To enable the functionality, the qmk_userspace_build.yml was extended to do the following:

- if exists, read json file `qmk_nontree.json` from the userspace root folder. This contains a simple string array property `nontree_targets`. The data is stored in an environment variable
- For each `target` in the array copy the files in the userspace/keyboards/`target` folder to the qmk_firmware/keyboards in the container
- User adds the non-tree keyboard to `qmk.json` as normal. The build will think the non-tree keyboard was part of qmk_firmware all along. The publish step will include the non-tree binary in the release

Example of the json file is below (put planck as it was in my userspace and I wanted to ensure multiple boards would be supported

```json
{
	"nontree_targets": [
		"barbellboards",
		"planck"
	]
}
```

Full implementation can be reviewed in my [userspace rollow branch](https://github.com/t4corun/qmk_userspace/tree/rollow) where I keep a non-tree keyboard and performed testing

An example run can be found [here](https://github.com/t4corun/qmk_userspace/actions/runs/8648339422)

Rollow definition that follows qmk_firmware standards. The entire rollow and planck folder would be copied
![image](https://github.com/qmk/.github/assets/87155454/4c0fd214-0409-404e-9192-d2437792e02f)

What the action does
![image](https://github.com/qmk/.github/assets/87155454/09c0c334-8141-4088-ad5b-acdfad89cbc1)

Results are published
![image](https://github.com/qmk/.github/assets/87155454/ca49eab9-a1ad-4ddd-ba90-fe2907c84279)





## Testing

Ran several test cases

- Negative conditions do not cause the entire action to fail
  - The `nontree_targets` property exists but array is empty
  - The `nontree_targets` property does not exist
  - If the JSON file does not end with a new line
  - If the JSON file does not exist
- Negative conditions that will result in a action failure
  - build step fails reporting the keyboard cannot be found after the non-tree keyboard definition not copying from any of above scenarios
  - If a the array has an entry that results in copy error; file/folder not found

## Things not addressed in this PR

- nodejs16 deprecation warning messages. That can be another PR 
- a separate PR to qmk/qmk_userspace to add the qmk_nontree.json template
