### PR TITLE
Add preparation command, update versions of workflows.

### DIFF
--- a/.github/workflows/qmk_userspace_build.yml
+++ b/.github/workflows/qmk_userspace_build.yml
@@ -13,6 +13,11 @@ on:
         default: "master"
         required: false
         type: string
+      preparation_command:
+        description: "command to execute before `qmk userspace-compile`"
+        default: ""
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -25,19 +30,19 @@ jobs:
 
     steps:
       - name: Checkout Userspace
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ github.token }}
           submodules: recursive
 
       - name: Check if qmk_firmware exists
         id: check_files
-        uses: andstor/file-existence-action@v2
+        uses: andstor/file-existence-action@v3
         with:
           files: qmk_firmware
 
       - name: Checkout QMK Firmware
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: steps.check_files.outputs.files_exists == 'false'
         with:
           token: ${{ github.token }}
@@ -61,6 +66,11 @@ jobs:
         run: |
           qmk userspace-doctor
 
+      - name: Preparation command
+        if: inputs.preparation_command != ''
+        run: |
+          ${{ inputs.preparation_command }}
+
       - name: Build
         run: |
           qmk userspace-compile -e DUMP_CI_METADATA=yes || touch .failed
@@ -72,7 +82,7 @@ jobs:
           [ ! -f .failed ] || exit 1
 
       - name: Upload binaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && !cancelled()
         continue-on-error: true
         with:

--- a/.github/workflows/qmk_userspace_publish.yml
+++ b/.github/workflows/qmk_userspace_publish.yml
@@ -21,10 +21,12 @@ jobs:
     steps:
       - name: Download binaries
         if: always() && !cancelled()
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          name: Firmware
 
       - name: Generate Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: always() && !cancelled()
         with:
           token: ${{ github.token }}


### PR DESCRIPTION
## Description

Allows for a command to be executed before `qmk userspace-compile`.

Also bumps dependent workflow actions to stop complaints about old node versions.