### PR TITLE
Print build error messages for compile workflow

### DIFF
--- a/.github/workflows/qmk_userspace_build.yml
+++ b/.github/workflows/qmk_userspace_build.yml
@@ -73,7 +73,7 @@ jobs:
 
       - name: Build
         run: |
-          qmk userspace-compile -e DUMP_CI_METADATA=yes || touch .failed
+          qmk userspace-compile -e DUMP_CI_METADATA=yes -p || touch .failed
           # Generate the step summary markdown
           ./qmk_firmware/util/ci/generate_failure_markdown.sh > $GITHUB_STEP_SUMMARY || true
           # Truncate to a maximum of 1MB to deal with GitHub workflow limit


### PR DESCRIPTION
Use the `userspace-compile -p` flag to show verbose errors when userspace builds via GitHub Actions fail.

Failure log before (no idea what I did wrong): https://github.com/bcat/qmk_userspace/actions/runs/19383283478/job/55465913714

Failure log after (oops, forgot `ENCODER_MAP_ENABLE`): https://github.com/bcat/qmk_userspace/actions/runs/19383530540/job/55466590376