### PR TITLE
Remove use of andstor/file-existence-action

### DIFF
--- a/.github/workflows/qmk_userspace_build.yml
+++ b/.github/workflows/qmk_userspace_build.yml
@@ -35,15 +35,9 @@ jobs:
           token: ${{ github.token }}
           submodules: recursive
 
-      - name: Check if qmk_firmware exists
-        id: check_files
-        uses: andstor/file-existence-action@v3
-        with:
-          files: qmk_firmware
-
       - name: Checkout QMK Firmware
         uses: actions/checkout@v6
-        if: steps.check_files.outputs.files_exists == 'false'
+        if: ${{ hashFiles('qmk_firmware/requirements.txt') == '' }}
         with:
           token: ${{ github.token }}
           path: qmk_firmware


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->

Action currently produces the following warning:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: andstor/file-existence-action@v3. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This PR updates to use functionality directly provided by actions instead.
